### PR TITLE
Fix typo sizeOfSringFor => sizeOfStringFor

### DIFF
--- a/Sources/Components/Description/DescriptionComponentView.swift
+++ b/Sources/Components/Description/DescriptionComponentView.swift
@@ -65,7 +65,7 @@ public class DescriptionComponentView: UIView {
             descriptionTextView.accessibilityAttributedLabel = component.text
 
             if component.isCollapsable {
-                if descriptionTextView.sizeOfSringFor(width: widthOfComponent).height <= showButtonHeightLimit {
+                if descriptionTextView.sizeOfStringFor(width: widthOfComponent).height <= showButtonHeightLimit {
                     descriptionTextView.bottomAnchor.constraint(equalTo: bottomAnchor).isActive = true
                 } else {
                     setupButton()

--- a/Sources/Extensions/UITextView+Components.swift
+++ b/Sources/Extensions/UITextView+Components.swift
@@ -5,7 +5,7 @@
 import UIKit
 
 extension UITextView {
-    func sizeOfSringFor(width: CGFloat) -> CGSize {
+    func sizeOfStringFor(width: CGFloat) -> CGSize {
         let textSize = CGSize(width: width, height: CGFloat(MAXFLOAT))
         return sizeThatFits(textSize)
     }


### PR DESCRIPTION
Found a small typo in a method name so I just fixed it up for you.

- The method had a typo, it has been renamed from `sizeOfSringFor` to
`sizeOfStringFor`.