### PR TITLE
Improve viewComponent(for...) in PawView

### DIFF
--- a/Paw.xcodeproj/project.pbxproj
+++ b/Paw.xcodeproj/project.pbxproj
@@ -348,7 +348,9 @@
 				44CAE2D31FE26C9F00F8AA9B /* Products */,
 				14E5C2152026055F0039A9A7 /* Frameworks */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		44CAE2D31FE26C9F00F8AA9B /* Products */ = {
 			isa = PBXGroup;

--- a/Sources/PawView.swift
+++ b/Sources/PawView.swift
@@ -149,70 +149,65 @@ public class PawView: UIView {
     }
 
     func viewComponent(for component: Component, in pawView: PawView) -> UIView? {
-        switch component.self {
-        case is TitleComponent:
+        var view: UIView?
+
+        switch component {
+        case let component as TitleComponent:
             let listComponentView = TitleComponentView()
-            listComponentView.translatesAutoresizingMaskIntoConstraints = false
-            listComponentView.component = component as? TitleComponent
-            return listComponentView
-        case is GalleryComponent:
+            listComponentView.component = component
+            view = listComponentView
+        case let component as GalleryComponent:
             let galleryComponentView = GalleryComponentView()
-            galleryComponentView.translatesAutoresizingMaskIntoConstraints = false
             galleryComponentView.delegate = pawView
-            galleryComponentView.component = component as? GalleryComponent
-            return galleryComponentView
-        case is CallToActionButtonComponent:
+            galleryComponentView.component = component
+            view = galleryComponentView
+        case let component as CallToActionButtonComponent:
             let listComponentView = CallToActionButtonComponentView()
-            listComponentView.translatesAutoresizingMaskIntoConstraints = false
             listComponentView.delegate = pawView
-            listComponentView.component = component as? CallToActionButtonComponent
-            return listComponentView
-        case is PhoneNumberComponent:
+            listComponentView.component = component
+            view = listComponentView
+        case let component as PhoneNumberComponent:
             let listComponentView = PhoneNumberComponentView()
-            listComponentView.translatesAutoresizingMaskIntoConstraints = false
             listComponentView.delegate = pawView
-            listComponentView.component = component as? PhoneNumberComponent
-            return listComponentView
-        case is LinkComponent:
+            listComponentView.component = component
+            view = listComponentView
+        case let component as LinkComponent:
             let listComponentView = LinkComponentView()
-            listComponentView.translatesAutoresizingMaskIntoConstraints = false
             listComponentView.delegate = pawView
-            listComponentView.component = component as? LinkComponent
-            return listComponentView
-        case is DescriptionComponent:
+            listComponentView.component = component
+            view = listComponentView
+        case let component as DescriptionComponent:
             let listComponentView = DescriptionComponentView()
-            listComponentView.translatesAutoresizingMaskIntoConstraints = false
             listComponentView.delegate = pawView
-            listComponentView.component = component as? DescriptionComponent
-            return listComponentView
-        case is PriceComponent:
+            listComponentView.component = component
+            view = listComponentView
+        case let component as PriceComponent:
             let listComponentView = PriceComponentView()
-            listComponentView.translatesAutoresizingMaskIntoConstraints = false
-            listComponentView.component = component as? PriceComponent
-            return listComponentView
-        case is SeparatorComponent:
+            listComponentView.component = component
+            view = listComponentView
+        case let component as SeparatorComponent:
             let separatorComponentView = SeparatorComponentView()
-            separatorComponentView.translatesAutoresizingMaskIntoConstraints = false
-            separatorComponentView.component = component as? SeparatorComponent
-            return separatorComponentView
-        case is TextListComponent:
+            separatorComponentView.component = component
+            view = separatorComponentView
+        case let component as TextListComponent:
             let textListComponentView = TextListComponentView()
-            textListComponentView.translatesAutoresizingMaskIntoConstraints = false
-            textListComponentView.component = component as? TextListComponent
-            return textListComponentView
-        case is DateListComponent:
+            textListComponentView.component = component
+            view = textListComponentView
+        case let component as DateListComponent:
             let dateListComponentView = DateListComponentView()
-            dateListComponentView.translatesAutoresizingMaskIntoConstraints = false
-            dateListComponentView.component = component as? DateListComponent
-            return dateListComponentView
-        case is PhoneNumberListComponent:
+            dateListComponentView.component = component
+            view = dateListComponentView
+        case let component as PhoneNumberListComponent:
             let phoneNumberListComponentView = PhoneNumberListComponentView()
-            phoneNumberListComponentView.translatesAutoresizingMaskIntoConstraints = false
             phoneNumberListComponentView.delegate = pawView
-            phoneNumberListComponentView.component = component as? PhoneNumberListComponent
-            return phoneNumberListComponentView
-        default: return nil
+            phoneNumberListComponentView.component = component
+            view = phoneNumberListComponentView
+        default: break
         }
+
+        view?.translatesAutoresizingMaskIntoConstraints = false
+
+        return view
     }
 }
 


### PR DESCRIPTION
## Set indent settings on Xcode project
By setting the indent and tab width on the project, Xcode will respect the project setting rather than the user-defined setting.

## Reduce type casting by using pattern matching
By using `case let` instead of `is`, we remove the additional casting when setting the component on the view.

Each case now sets a value to `view` instead of returning, this has the potential to make debugging easier as you can set a breakpoint at the very end to check the output value.

Because the framework uses constraints, we want to always set `translatesAutoresizingMaskIntoConstraints` to `false`. This is now handled before the return instead in each case.